### PR TITLE
Use more portable shebang for bash

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 APPS=apps
 APP=$(basename `pwd`)


### PR DESCRIPTION
Fix for FreeBSD. Still requires bash but that should be ok IMO.
